### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,27 @@
 
 
 
+## [0.1.2] - 2024-03-30
+
+### 🚜 Refactor
+
+- Add token_kind()
+
+### 🧪 Testing
+
+- Add a failing test for inner expansion
+- Fix expected output
+- Add a failing test for inline object expansion
+
+### ⚙️ Miscellaneous Tasks
+
+- Install git-cliff
+
+### Minor
+
+- Moved tests to a separate file
+- Fix typo
+- Add/remove comments
+- Code simplification
+- Rename a test function
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 exclude = [
     ".github/*",


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2] - 2024-03-30

### 🚜 Refactor

- Add token_kind()

### 🧪 Testing

- Add a failing test for inner expansion
- Fix expected output
- Add a failing test for inline object expansion

### ⚙️ Miscellaneous Tasks

- Install git-cliff

### Minor

- Moved tests to a separate file
- Fix typo
- Add/remove comments
- Code simplification
- Rename a test function
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).