### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 
 
+## [0.2.1] - 2024-03-30
+
+### 🚀 Features
+
+- Introduce "gen.os"
+- @@ now honours gen.os
+- Testing feat commit message tag
+
+### 🐛 Bug Fixes
+
+- Reduce indentation to match vscode
+- Gen.globals were being inserted if not present in template
+
+### 📚 Documentation
+
+- Mention gen.os
+
+### ⚙️ Miscellaneous Tasks
+
+- Install git-cliff via action so it's cached
+- Add .pre-commit support
+
 ## [0.1.2] - 2024-03-30
 
 ### 🚜 Refactor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -217,7 +217,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 exclude = [
     ".github/*",


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1] - 2024-03-30

### 🚀 Features

- Introduce "gen.os"
- @@ now honours gen.os
- Testing feat commit message tag

### 🐛 Bug Fixes

- Reduce indentation to match vscode
- Gen.globals were being inserted if not present in template

### 📚 Documentation

- Mention gen.os

### ⚙️ Miscellaneous Tasks

- Install git-cliff via action so it's cached
- Add .pre-commit support
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).