### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 
 
+## [1.1.0] - 2024-03-31
+
+### 🚀 Features
+
+- Support a .vscode-workspace-gen.json file
+- Allow to generate per OS
+
+### 📚 Documentation
+
+- Fix README typo
+- Make it clear that macos is an available gen.os value
+- Updated README regarding json_indent
+
+### ⚙️ Miscellaneous Tasks
+
+- *(vscode)* Regenerate workspace
+- Update Cargo.lock
+
 ## [0.2.2] - 2024-03-30
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 exclude = [
     ".github/*",


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 1.0.0 -> 1.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.0] - 2024-03-31

### 🚀 Features

- Support a .vscode-workspace-gen.json file
- Allow to generate per OS

### 📚 Documentation

- Fix README typo
- Make it clear that macos is an available gen.os value
- Updated README regarding json_indent

### ⚙️ Miscellaneous Tasks

- *(vscode)* Regenerate workspace
- Update Cargo.lock
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).