### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 
 
+## [1.2.0] - 2024-03-31
+
+### 🚀 Features
+
+- Added --download_qtnatvis option
+
+### ⚙️ Miscellaneous Tasks
+
+- *(vscode)* Qualify the json extension a bit more
+- *(vscode)* Update workspace file
+
 ## [1.1.0] - 2024-03-31
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,7 +1075,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "clap",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 exclude = [
     ".github/*",


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 1.1.0 -> 1.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.0] - 2024-03-31

### 🚀 Features

- Added --download_qtnatvis option

### ⚙️ Miscellaneous Tasks

- *(vscode)* Qualify the json extension a bit more
- *(vscode)* Update workspace file
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).