### PR TITLE
chore: release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 
 
+## [1.4.0] - 2024-04-04
+
+### 🚀 Features
+
+- Add --create-cmake-presets
+
+### 🧪 Testing
+
+- Remove old natvis before running test_download_qtnatvis
+
+### ⚙️ Miscellaneous Tasks
+
+- *(ci)* Pass --features qt to clippy
+
 ## [1.3.0] - 2024-04-03
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "clap",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 exclude = [
     ".github/*",


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 1.3.0 -> 1.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.4.0] - 2024-04-04

### 🚀 Features

- Add --create-cmake-presets

### 🧪 Testing

- Remove old natvis before running test_download_qtnatvis

### ⚙️ Miscellaneous Tasks

- *(ci)* Pass --features qt to clippy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).