### PR TITLE
chore: release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 
 
+## [1.4.0] - 2024-04-16
+
+### 🚀 Features
+
+- Add --create-cmake-presets
+- Add --create-default-vscode-workspace convenience for Qt
+
+### 📚 Documentation
+
+- Improve docs
+
+### 🧪 Testing
+
+- Remove old natvis before running test_download_qtnatvis
+
+### ⚙️ Miscellaneous Tasks
+
+- *(ci)* Pass --features qt to clippy
+- Added workflow to run cargo update
+- Rename cargo workflow name
+- Setup git author name for cargo update PR
+- Minor comments
+- Cargo update
+- Added a build.sh
+
 ## [1.3.0] - 2024-04-03
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "hyper"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f24ce812868d86d19daa79bf3bf9175bc44ea323391147a5e3abde2a283871b"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1120,7 +1120,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "clap",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 exclude = [
     ".github/*",


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 1.3.0 -> 1.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.4.0] - 2024-04-16

### 🚀 Features

- Add --create-cmake-presets
- Add --create-default-vscode-workspace convenience for Qt

### 📚 Documentation

- Improve docs

### 🧪 Testing

- Remove old natvis before running test_download_qtnatvis

### ⚙️ Miscellaneous Tasks

- *(ci)* Pass --features qt to clippy
- Added workflow to run cargo update
- Rename cargo workflow name
- Setup git author name for cargo update PR
- Minor comments
- Cargo update
- Added a build.sh
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).