### PR TITLE
chore: release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 
 
+## [1.5.0] - 2024-04-16
+
+### 🚀 Features
+
+- Warn the user if Qt env vars are missing
+
+### ⚙️ Miscellaneous Tasks
+
+- Minor rename
+- Fix build
+- Fix non-qt build
+
 ## [1.4.0] - 2024-04-16
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,7 +1120,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "clap",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 exclude = [
     ".github/*",


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 1.4.0 -> 1.5.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.5.0] - 2024-04-16

### 🚀 Features

- Warn the user if Qt env vars are missing

### ⚙️ Miscellaneous Tasks

- Minor rename
- Fix build
- Fix non-qt build
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).