### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 
 
+## [2.0.0] - 2024-05-10
+
+### 🚀 Features
+
+- [**breaking**] Cleanup args handling
+
+### ⚙️ Miscellaneous Tasks
+
+- Remove unneeded strategy from ci yml file
+
 ## [1.7.0] - 2024-05-08
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "1.7.0"
+version = "2.0.0"
 dependencies = [
  "clap",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "1.7.0"
+version = "2.0.0"
 edition = "2021"
 exclude = [
     ".github/*",


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 1.7.0 -> 2.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0] - 2024-05-10

### 🚀 Features

- [**breaking**] Cleanup args handling

### ⚙️ Miscellaneous Tasks

- Remove unneeded strategy from ci yml file
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).