### PR TITLE
chore: release v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 
 
+## [2.2.2] - 2024-05-21
+
+### 🐛 Bug Fixes
+
+- Fix outdated README
+
+### 📚 Documentation
+
+- Explain people should fix their issues instead of reporting
+
 ## [2.2.1] - 2024-05-20
 
 ### ⚙️ Miscellaneous Tasks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "clap",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2021"
 exclude = [".github/*", "vscode*"]
 homepage = "https://github.com/iamsergio/vscode-workspace-gen"


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 2.2.1 -> 2.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.2.2] - 2024-05-21

### 🐛 Bug Fixes

- Fix outdated README

### 📚 Documentation

- Explain people should fix their issues instead of reporting
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).