### PR TITLE
chore: release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 
 
+## [3.0.0] - 2024-06-01
+
+### 🚀 Features
+
+- -c is now short-hand for --create project
+- Allow to copy projects without their parent folder
+- [**breaking**] Remove qt feature
+
+### ⚙️ Miscellaneous Tasks
+
+- Use serde deserialize to read to struct in one go
+- Minor rename
+- Minor refactoring for readability
+
 ## [2.3.0] - 2024-05-28
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,9 +1119,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1260,7 +1260,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "2.3.0"
+version = "3.0.0"
 dependencies = [
  "clap",
  "comfy-table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "2.3.0"
+version = "3.0.0"
 edition = "2021"
 exclude = [".github/*", "vscode*"]
 homepage = "https://github.com/iamsergio/vscode-workspace-gen"


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 2.3.0 -> 3.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.0] - 2024-06-01

### 🚀 Features

- -c is now short-hand for --create project
- Allow to copy projects without their parent folder
- [**breaking**] Remove qt feature

### ⚙️ Miscellaneous Tasks

- Use serde deserialize to read to struct in one go
- Minor rename
- Minor refactoring for readability
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).