### PR TITLE
chore: release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 
 
+## [3.1.0] - 2024-06-03
+
+### 🚀 Features
+
+- Display a "type" column when listing projects
+- Add "depends" json field
+
+### ⚙️ Miscellaneous Tasks
+
+- Cargo update
+
 ## [3.0.0] - 2024-06-01
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,7 +1254,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "clap",
  "comfy-table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 exclude = [".github/*", "vscode*"]
 homepage = "https://github.com/iamsergio/vscode-workspace-gen"


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 3.0.0 -> 3.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.1.0] - 2024-06-03

### 🚀 Features

- Display a "type" column when listing projects
- Add "depends" json field

### ⚙️ Miscellaneous Tasks

- Cargo update
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).