### PR TITLE
chore: release v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 
 
+## [3.1.1] - 2024-06-03
+
+### 🐛 Bug Fixes
+
+- Remove reqwest as dependency
+
 ## [3.1.0] - 2024-06-03
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "clap",
  "comfy-table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2021"
 exclude = [".github/*", "vscode*"]
 homepage = "https://github.com/iamsergio/vscode-workspace-gen"


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 3.1.0 -> 3.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.1.1] - 2024-06-03

### 🐛 Bug Fixes

- Remove reqwest as dependency
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).