### PR TITLE
chore: release v3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 
 
+## [3.1.2] - 2024-12-23
+
+### 🐛 Bug Fixes
+
+- Make clippy happy which fixes CI
+
 ## [3.1.1] - 2024-06-03
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,7 +459,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "clap",
  "comfy-table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "3.1.1"
+version = "3.1.2"
 edition = "2021"
 exclude = [".github/*", "vscode*"]
 homepage = "https://github.com/iamsergio/vscode-workspace-gen"


### PR DESCRIPTION
## 🤖 New release
* `vscode-workspace-gen`: 3.1.1 -> 3.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.1.2] - 2024-12-23

### 🐛 Bug Fixes

- Make clippy happy which fixes CI
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).