### PR TITLE
chore: release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 
 
+## [3.2.0] - 2025-07-04
+
+### 🚀 Features
+
+- Allow to create template from template
+
+### 🐛 Bug Fixes
+
+- Don't nag about existing directory when copying single_file
+
 ## [3.1.3] - 2025-03-31
 
 ### ⚙️ Miscellaneous Tasks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "3.1.3"
+version = "3.2.0"
 dependencies = [
  "clap",
  "comfy-table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "3.1.3"
+version = "3.2.0"
 edition = "2021"
 exclude = [".github/*", "vscode*"]
 homepage = "https://github.com/iamsergio/vscode-workspace-gen"


### PR DESCRIPTION



## 🤖 New release

* `vscode-workspace-gen`: 3.1.3 -> 3.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.2.0] - 2025-07-04

### 🚀 Features

- Allow to create template from template

### 🐛 Bug Fixes

- Don't nag about existing directory when copying single_file
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).