### PR TITLE
chore: release v3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 
 
+## [3.2.1] - 2026-05-02
+
+### ⚙️ Miscellaneous Tasks
+
+- Update Cargo.lock dependencies
+
+
 ## [3.2.0] - 2025-07-04
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vscode-workspace-gen"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "clap",
  "comfy-table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "vscode-workspace-gen"
-version = "3.2.0"
+version = "3.2.1"
 edition = "2021"
 exclude = [".github/*", "vscode*"]
 homepage = "https://github.com/iamsergio/vscode-workspace-gen"


### PR DESCRIPTION



## 🤖 New release

* `vscode-workspace-gen`: 3.2.0 -> 3.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.2.1] - 2026-05-02

### ⚙️ Miscellaneous Tasks

- Update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).